### PR TITLE
allow paths with periods in the middle, but not with leading slash

### DIFF
--- a/lib/rack-zippy.rb
+++ b/lib/rack-zippy.rb
@@ -63,7 +63,7 @@ module Rack
 
       ACCEPTS_GZIP_REGEX = /\bgzip\b/
 
-      ILLEGAL_PATH_REGEX = /(\/\.\.|\/\.)/
+      ILLEGAL_PATH_REGEX = /(\/\.\.?)/
 
       def client_accepts_gzip?(rack_env)
         rack_env['HTTP_ACCEPT_ENCODING'] =~ ACCEPTS_GZIP_REGEX

--- a/lib/rack-zippy.rb
+++ b/lib/rack-zippy.rb
@@ -63,7 +63,7 @@ module Rack
 
       ACCEPTS_GZIP_REGEX = /\bgzip\b/
 
-      ILLEGAL_PATH_REGEX = /(\.\.|\/\.)/
+      ILLEGAL_PATH_REGEX = /(\/\.\.|\/\.)/
 
       def client_accepts_gzip?(rack_env)
         rack_env['HTTP_ACCEPT_ENCODING'] =~ ACCEPTS_GZIP_REGEX

--- a/test/asset_server_test.rb
+++ b/test/asset_server_test.rb
@@ -192,16 +192,16 @@ module Rack
       end
 
       def test_responds_not_found_if_path_contains_consecutive_periods
-        ["/hello/../sensitive/file", "/..", "/..."].each do |dotty_path|
+        ["/hello/../sensitive/file", "/..", "/...", "../sensitive"].each do |dotty_path|
           get dotty_path
           assert_not_found
         end
       end
 
       def test_responds_ok_if_path_contains_periods_that_not_follow_slash
-         ["/hello/path..with....periouds/file", "/hello/path/with..periods"].each do |dotty_path|
+         ["/hello/path..with....periods/file", "/hello/path/with.a.period"].each do |dotty_path|
           get dotty_path
-          assert_response_ok
+          assert_underlying_app_responded
         end
       end
 

--- a/test/asset_server_test.rb
+++ b/test/asset_server_test.rb
@@ -198,6 +198,13 @@ module Rack
         end
       end
 
+      def test_responds_ok_if_path_contains_periods_that_not_follow_slash
+         ["/hello/path..with....periouds/file", "/hello/path/with..periods"].each do |dotty_path|
+          get dotty_path
+          assert_response_ok
+        end
+      end
+
       def test_serves_html
         assert_responds_with_html_file '/thanks.html', 'public/thanks.html'
       end


### PR DESCRIPTION
Hey,

this is about multiple dots in URL problem. 
I know you've been working on this before (https://github.com/eliotsykes/rack-zippy/issues/17), but  I want to propose a bit modified solution that I've created for myself. It allows paths like /something...with..dots/ but still respond 404 on paths like /.. or /..something

Thanks,
-Simon